### PR TITLE
Improve offline banner placement

### DIFF
--- a/RadioRSS/Views/ContentView.swift
+++ b/RadioRSS/Views/ContentView.swift
@@ -24,9 +24,8 @@ struct ContentView: View {
                 .tag(2)
                 .tabItem { Label("Settings", systemImage: "gearshape.fill") }
         }
-        .overlay(alignment: .top) {
+        .safeAreaInset(edge: .top) {
             OfflineBannerView()
-                .ignoresSafeArea()
         }
         .overlay(alignment: .bottom) {
             MiniPlayerView()


### PR DESCRIPTION
## Summary
- show network banner with `safeAreaInset` so it's visible on all screen shapes

## Testing
- `swift --version`
