### PR TITLE
Fix navigation bar blocked by offline banner

### DIFF
--- a/RadioRSS/Views/ContentView.swift
+++ b/RadioRSS/Views/ContentView.swift
@@ -24,9 +24,8 @@ struct ContentView: View {
                 .tag(2)
                 .tabItem { Label("Settings", systemImage: "gearshape.fill") }
         }
-        .overlay(alignment: .top) {
+        .safeAreaInset(edge: .top) {
             OfflineBannerView()
-                .ignoresSafeArea()
         }
         .overlay(alignment: .bottom) {
             MiniPlayerView()

--- a/RadioRSS/Views/OfflineBannerView.swift
+++ b/RadioRSS/Views/OfflineBannerView.swift
@@ -11,6 +11,8 @@ struct OfflineBannerView: View {
                 .background(Color.red.opacity(0.9))
                 .foregroundColor(.white)
                 .transition(.move(edge: .top))
+                .allowsHitTesting(false)
+                .zIndex(1)
         }
     }
 }


### PR DESCRIPTION
## Summary
- ensure offline banner doesn't intercept taps when visible

## Testing
- `swift --version`
