### PR TITLE
Fix offline banner overlay

### DIFF
--- a/RadioRSS/Views/ContentView.swift
+++ b/RadioRSS/Views/ContentView.swift
@@ -12,6 +12,8 @@ struct ContentView: View {
     @State private var selection = 0
     @EnvironmentObject private var player: PlayerViewModel
 
+    @Environment(\.safeAreaInsets) private var safeAreaInsets
+
     var body: some View {
         TabView(selection: $selection) {
             StationsView()
@@ -26,7 +28,9 @@ struct ContentView: View {
         }
         .overlay(alignment: .top) {
             OfflineBannerView()
-                .ignoresSafeArea()
+                .padding(.top, safeAreaInsets.top)
+                .allowsHitTesting(false)
+                .zIndex(1)
         }
         .overlay(alignment: .bottom) {
             MiniPlayerView()


### PR DESCRIPTION
## Summary
- overlay the offline banner and offset by the top safe area so it appears above the toolbar on all devices

## Testing
- `swift --version`
